### PR TITLE
Update minimum Java version requirement

### DIFF
--- a/WikipediaCleaner/resources/getdown/getdown.txt
+++ b/WikipediaCleaner/resources/getdown/getdown.txt
@@ -98,7 +98,7 @@ resource = tasks/metawiki/_Monthly.txt
 resource = tasks/metawiki/ListCheckWiki.txt
 
 # Requirements on Java
-java_min_version = 1080000
+java_min_version = 1170000
 # java_location = [windows] /java_vm/java_windows.jar
 # java_location = [linux] /java_vm/java_linux.jar
 


### PR DESCRIPTION
Require Java 17 to match the project’s build target.